### PR TITLE
Solving bug in license-activated simulator

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,18 +23,36 @@ int main(int argc, char **argv)
   //setlocale(LC_NUMERIC, "de_DE"); // German locale (or any other locale that uses a comma)
   multimap <double, string> time_series;
  
-#if defined LICENSED
-  int check_license = validate_license();
-  if(check_license < 0){
-    return -1;
-  }
-#endif
   // initialize MPI
   MPI_Init( &argc, &argv );
   MPI_Comm_size( MPI_COMM_WORLD, &MPI_Profile::size );
   MPI_Comm_rank( MPI_COMM_WORLD, &MPI_Profile::rank );
   MPI_Get_processor_name( MPI_Profile::host_name, &MPI_Profile::host_name_len );
 
+#if defined LICENSED
+  int license_retval = 0;
+  int check_license = 0;
+
+  if (MPI_Profile::rank == 0) {
+    check_license = validate_license();
+    if (check_license < 0) {
+      license_retval = -1;
+    }
+  }
+
+  // Broadcast the license result to all processes
+  MPI_Bcast(&license_retval, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+  // All processes check the license result
+  if (license_retval < 0) {
+    MPI_Finalize();
+    return -1;
+  }
+
+  // Only proceed with barrier if license check passed
+  MPI_Barrier(MPI_COMM_WORLD);
+#endif
+  
   // input parameter object
   Parameter *p_param;
   p_param = new Parameter();


### PR DESCRIPTION
Insert the license checking into MPI parts. The CPU0 doing the checking of the license, and broadcasting the result to all CPU. If the license retrieval got error, execute the MPI_Finalize() and return -1.