### PR TITLE
Giving conditional statement for postprocessing module

### DIFF
--- a/bin/simulation_cpu_postprocessing/exec_bash.sh
+++ b/bin/simulation_cpu_postprocessing/exec_bash.sh
@@ -82,7 +82,7 @@ if [ $EXIT_CODE -ne 0 ]; then
 fi
 echo "Unzipping successful!!!" >> "${RESULT_FOLDER}/logfile" 2>&1
 echo "Run ${CELL_MODEL} cell model postprocessing simulation with ${NUMBER_OF_CPU} cores."
-( echo $$ > "${PIDFILE}"; exec mpiexec -np "${NUMBER_OF_CPU}" "${BINARY_FILE}" -input_deck param.txt >> "${RESULT_FOLDER}/logfile") 2>&1
+( echo $$ > "${PIDFILE}"; exec mpiexec -np "${NUMBER_OF_CPU}" "${BINARY_FILE}" -input_deck param.txt >> "${RESULT_FOLDER}/logfile" 2>&1)
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
   echo "Simulation program got some problems!!! Exiting..." >> "${RESULT_FOLDER}/logfile" 2>&1

--- a/bin/simulation_cpu_postprocessing/param.txt
+++ b/bin/simulation_cpu_postprocessing/param.txt
@@ -11,5 +11,5 @@ drug_name = quinidine							// Name of the drug
 drug_concentrations = 3237,6474	// Concentration of the drug, Cmax1 to Cmax4 values (mMolar)
 hill_file = ./chantest_hill/quinidine/IC50_samples10.csv	// File that contains the IC50 information for each ionic channel.
 herg_file = ./chantest_herg/quinidine/boot_pars10.csv			// File that contains the hERG parameters.
-initial_values_zip_file = ./initial_values_zips/quinidine_ToR-ORd-dynCl_endo_initial_values.zip // Zip file containing the initial values from in silico simulation
+initial_values_zip_file = ./initial_values_zips/quinidine_CiPAORdv1.0_endo_initial_values.zip // Zip file containing the initial values from in silico simulation
 number_of_cpu = 10               // Number of CPU used for mpiexec call

--- a/modules/postprocessing.cpp
+++ b/modules/postprocessing.cpp
@@ -110,7 +110,14 @@ int postprocessing(double conc, double inal_auc_control, double ical_auc_control
   }
   mpi_printf(cml::commons::MASTER_NODE, "\nUsing initial values from the in-silico simulation.\n");
 
-  copy(p_features.initial_values.begin(), p_features.initial_values.end(), p_cell->STATES);
+  if( p_features.initial_values.size() != p_cell->states_size ){
+    mpi_fprintf(cml::commons::MASTER_NODE, stderr, "Data mismatch between cell model and initial values file!!\n",buffer);
+    return 1;    
+  }
+  else {
+    copy(p_features.initial_values.begin(), p_features.initial_values.end(), p_cell->STATES);
+  }
+
   for( int idx = 0; idx < p_cell->states_size; idx++ ){
     p_cell->STATES[idx] = p_features.initial_values[idx];
   }


### PR DESCRIPTION
- give some conditional check in the postprocessing when the user use different initial values zip file from the cell model. For instance, they want to simulate CiPAORdv1.0 cell model, but using ToR-ORd initial value zip file. Thanks to Uzan who found this bug, so I give conditional check to prevent the bug happened, and giving some error message instead.
- Fixing minor details to the exec_bash script in postprocessing so that the error message will be printed in the logfile. CardioSim user will see the error when something unexpected happened.